### PR TITLE
fix for kirby5

### DIFF
--- a/classes/AutoFileTemplates.php
+++ b/classes/AutoFileTemplates.php
@@ -24,7 +24,7 @@ readonly class AutoFileTemplates
         }
 
         // Do not overwrite existing templates
-        if ($this->options->forceOverwrite === false && $file->template() !== 'default') {
+        if ($this->options->forceOverwrite === false && $this->fileHasTemplate($file->template())) {
             return null;
         }
 
@@ -90,5 +90,9 @@ readonly class AutoFileTemplates
         }
 
         return $map;
+    }
+    private function fileHasTemplate(?string $template): bool
+    {
+        return $template !== null && $template !== 'default';
     }
 }

--- a/classes/AutoFileTemplates.php
+++ b/classes/AutoFileTemplates.php
@@ -24,7 +24,7 @@ readonly class AutoFileTemplates
         }
 
         // Do not overwrite existing templates
-        if ($this->options->forceOverwrite === false && $file->template() !== null) {
+        if ($this->options->forceOverwrite === false && $file->template() !== 'default') {
             return null;
         }
 

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ App::plugin('presprog/auto-file-templates', [
     'hooks' => [
         'file.create:after' => function (File $file) {
             $options = PluginOptions::createFromOptions(kirby()->options());
-            return (new AutoFileTemplates(kirby(), $options))->autoAssign($file);
+            (new AutoFileTemplates(kirby(), $options))->autoAssign($file);
         },
     ],
 ]);


### PR DESCRIPTION
the plugin did nothing in kirby5 because the default template in kirby5 is now `'default'`. 
in kirby4 this was `null`.

therefor the condition was not working in kirby5 anymore.
also the file hook is supposed to return nothing.

this PR fixes that.